### PR TITLE
fix(contextMenu): no more error when context menu is called outside data

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -121,7 +121,8 @@
         "max-lines-per-function": "off",
         "max-statements": "off",
         "vitest/prefer-to-be-truthy": "off",
-        "vitest/prefer-to-be-falsy": "off"
+        "vitest/prefer-to-be-falsy": "off",
+        "vitest/require-test-timeout": "warn"
       }
     },
     {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -207,6 +207,9 @@ async function openMenu(event) {
   const yUI = event.clientY - rect.top;
 
   await get_viewer_id(x, yPicking);
+  if (!id.value) {
+    return;
+  }
   const item = await dataStore.item(id.value);
 
   menuStore.openMenu(


### PR DESCRIPTION
Error Message in dev console :

dexie.js?v=845a50d9:1379 Uncaught (in promise) TypeError: Invalid argument to Table.get()
    at Table2.get (dexie.js?v=845a50d9:1379:30)
    at Proxy.item (data.js:16:43)
    at Proxy.wrappedAction (pinia.mjs?v=845a50d9:1071:18)
    at store.<computed> (pinia.mjs?v=845a50d9:768:44)
    at openMenu (index.vue?t=1774963285167:66:32)